### PR TITLE
Adding support for managing DNS zones

### DIFF
--- a/lib/moo_moo.rb
+++ b/lib/moo_moo.rb
@@ -10,6 +10,7 @@ module MooMoo
   autoload :Nameserver,        'moo_moo/nameserver'
   autoload :Provisioning,      'moo_moo/provisioning'
   autoload :Transfer,          'moo_moo/transfer'
+  autoload :DnsZone,           'moo_moo/dns_zone'
   autoload :Cookie,            'moo_moo/cookie'
   autoload :OpenSRSErrors,     'moo_moo/middleware/open_srs_errors'
   autoload :ParseOpenSRS,      'moo_moo/middleware/parse_open_srs'

--- a/lib/moo_moo/dns_zone.rb
+++ b/lib/moo_moo/dns_zone.rb
@@ -1,0 +1,45 @@
+module MooMoo
+  class DnsZone < Base
+
+    ##
+    # Creates a custom DNS zone for managed DNS service.
+    #
+    # http://www.opensrs.com/docs/apidomains/create_dns_zone_request.htm
+    register_service :create_dns_zone, :domain
+
+    ##
+    # Deletes the DNS zones for the specified domain.
+    #
+    # http://www.opensrs.com/docs/apidomains/delete_dns_zone_request.htm
+    register_service :delete_dns_zone, :domain
+
+    ##
+    # Changes the nameservers on your domain to use the 
+    # nameservers for managed DNS service.
+    #
+    # http://www.opensrs.com/docs/apidomains/Request_parameters_for_force_dns_nameservers.htm
+    register_service :force_dns_nameservers, :domain
+
+    ##
+    # View the DNS records for a specified domain.
+    #
+    # http://www.opensrs.com/docs/apidomains/get_dns_zone_request.htm
+    register_service :get_dns_zone, :domain
+
+    ##
+    # Sets the DNS zone to the values in the specified template.
+    # If a template is not specified in the command, the records 
+    # are set to what was in the template that was used to enable 
+    # the DNS service.
+    #
+    # http://www.opensrs.com/docs/apidomains/reset_dns_zone_request.htm
+    register_service :reset_dns_zone, :domain
+
+    ##
+    # Set the records for a domain's DNS zone.
+    #
+    # http://www.opensrs.com/docs/apidomains/set_dns_zone_request.htm
+    register_service :set_dns_zone, :domain
+
+  end
+end

--- a/spec/moo_moo/dns_zone_spec.rb
+++ b/spec/moo_moo/dns_zone_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'date'
+
+describe MooMoo::DnsZone do
+  it { should have_registered_service(:create_dns_zone, :domain) }
+  it { should have_registered_service(:delete_dns_zone, :domain) }
+  it { should have_registered_service(:force_dns_nameservers, :domain) }
+  it { should have_registered_service(:get_dns_zone, :domain) }
+  it { should have_registered_service(:reset_dns_zone, :domain) }
+  it { should have_registered_service(:set_dns_zone, :domain) }
+end


### PR DESCRIPTION
I've added some code to connect to the OpenSRS managed DNS service, along with corresponding tests that follow the conventions established in the other spec files. 

I needed this functionality for a project I'm working so did some quick work to implement it. I'll likely need to add support for a few more API endpoints over the next few weeks (months?), so let me know if you're open to more pull requests or if you'd prefer I work independently on my own fork :)
