### PR TITLE
Remove unused variable from parse_open_srs middleware

### DIFF
--- a/lib/moo_moo/middleware/parse_open_srs.rb
+++ b/lib/moo_moo/middleware/parse_open_srs.rb
@@ -21,8 +21,6 @@ module MooMoo
     def parse_response(data)
       doc = REXML::Document.new(data)
 
-      values = {}
-
       elements = doc.elements["/OPS_envelope/body/data_block/dt_assoc"].select { |item|
         item.is_a? REXML::Element
       }


### PR DESCRIPTION
I was looking at the code and I saw a unused variable so I removed it.
