### PR TITLE
Password is unnecessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ First, create an opensrs object for the namespace you want to use:
 lookup = MooMoo::Lookup.new(
   host:     "horizon.opensrs.net",
   key:      "<YOUR_KEY>",
-  username: "<YOUR_RESELLER_USER>",
-  password: "<YOUR_PASSWORD>"
+  username: "<YOUR_RESELLER_USER>"
 )
 ```
 Or configure MooMoo and you can initialize it without any arguments:
@@ -39,7 +38,6 @@ MooMoo.configure do |config|
   config.host     = "horizon.opensrs.net"
   config.key      = "<YOUR_KEY>"
   config.username = "<YOUR_RESELLER_USER>"
-  config.password = "<YOUR_PASSWORD>"
 end
 
 ...

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ end
 
 desc "Sanitize sensitive info from cassettes"
 task :sanitize_cassettes do
-  if ENV['OPENSRS_TEST_KEY'] && ENV['OPENSRS_TEST_URL'] && ENV['OPENSRS_TEST_USER'] && ENV['OPENSRS_TEST_PASS']
+  if ENV['OPENSRS_TEST_KEY'] && ENV['OPENSRS_TEST_URL'] && ENV['OPENSRS_TEST_USER']
     path = File.join(File.dirname(__FILE__), 'spec', 'vcr_cassettes')
     files = Dir.glob("#{path}/**/*.yml")
     if files.any?
@@ -35,7 +35,6 @@ task :sanitize_cassettes do
         old.gsub!(ENV['OPENSRS_TEST_KEY'], '123key')
         old.gsub!(ENV['OPENSRS_TEST_URL'], 'server.com')
         old.gsub!(ENV['OPENSRS_TEST_USER'], 'opensrs_user')
-        old.gsub!(ENV['OPENSRS_TEST_PASS'], 'password')
         old.gsub!(/x-signature.*?\n.*?\w{32}/, "x-signature:\n      - 00000000000000000000000000000000")
         old.gsub!(/\w{16}:\w{6}:\w{2,8}/, '0000000000000000:000000:00000')
         File.open(file, 'w') do |f|
@@ -46,7 +45,7 @@ task :sanitize_cassettes do
       puts "Nothing to sanitize"
     end
   else
-    puts "I can't sanitize without setting up OPENSRS_TEST_KEY, OPENSRS_TEST_URL, OPENSRS_TEST_USER, and OPENSRS_TEST_PASS"
+    puts "I can't sanitize without setting up OPENSRS_TEST_KEY, OPENSRS_TEST_URL, OPENSRS_TEST_USER"
   end
 end
 

--- a/lib/moo_moo/base_command.rb
+++ b/lib/moo_moo/base_command.rb
@@ -13,7 +13,7 @@ module MooMoo
   #       ... custom response processing ...
   #     end
   class BaseCommand
-    attr_reader :host, :key, :username, :password, :port, :response
+    attr_reader :host, :key, :username, :port, :response
 
     # Register an api service for the current class.
     #
@@ -37,7 +37,6 @@ module MooMoo
     #  * <tt>:host</tt> - host of the OpenSRS server
     #  * <tt>:key</tt> - private key
     #  * <tt>:username</tt> - username of the reseller
-    #  * <tt>:password</tt> - password of the rseller
     #
     # === Optional
     #  * <tt>:port</tt> - port to connect on
@@ -45,7 +44,6 @@ module MooMoo
       @host     = params[:host]     || MooMoo.config.host     || raise(OpenSRSException, "Host is required")
       @key      = params[:key]      || MooMoo.config.key      || raise(OpenSRSException, "Key is required")
       @username = params[:username] || MooMoo.config.username || raise(OpenSRSException, "Username is required")
-      @password = params[:password] || MooMoo.config.password || raise(OpenSRSException, "Password is required")
       @port     = params[:port]     || MooMoo.config.port     || 55443
     end
 

--- a/lib/moo_moo/config.rb
+++ b/lib/moo_moo/config.rb
@@ -5,7 +5,6 @@ module MooMoo
     attr_accessor :host
     attr_accessor :key
     attr_accessor :username
-    attr_accessor :password
     attr_accessor :port
     attr_accessor :logger
 
@@ -13,7 +12,6 @@ module MooMoo
       @host     = default_option("host") || 'horizon.opensrs.net'
       @key      = default_option("key")
       @username = default_option("username")
-      @password = default_option("password")
       @port     = default_option("port")
     end
 

--- a/spec/moo_moo/base_command_spec.rb
+++ b/spec/moo_moo/base_command_spec.rb
@@ -7,7 +7,7 @@ end
 describe MooMoo::BaseCommand do
 
   subject { SampleService.new(:host => "thehost.com", :key => "thekey",
-      :username => "theuser", :password => "thepass", :port => "12345") }
+      :username => "theuser", :port => "12345") }
 
   let(:response) { double("Response", :body => {"attributes" => { :the => :attrs }})}
 

--- a/spec/moo_moo/config_spec.rb
+++ b/spec/moo_moo/config_spec.rb
@@ -8,7 +8,6 @@ describe MooMoo::Config do
   it { @config.should have_attr_accessor :host }
   it { @config.should have_attr_accessor :key  }
   it { @config.should have_attr_accessor :username }
-  it { @config.should have_attr_accessor :password }
   it { @config.should have_attr_accessor :port }
 
   describe "default configuration" do
@@ -19,7 +18,6 @@ describe MooMoo::Config do
         host: thehost
         key: thekey
         username: theuser
-        password: thepass
         port: theport
         "
       )
@@ -37,10 +35,6 @@ describe MooMoo::Config do
 
     it "should set default user from default options file" do
       @config.username.should == "theuser"
-    end
-
-    it "should set default pass from default options file" do
-      @config.password.should == "thepass"
     end
 
     it "should set default port from default options file" do

--- a/spec/moo_moo_spec.rb
+++ b/spec/moo_moo_spec.rb
@@ -15,7 +15,6 @@ describe MooMoo do
         config.host     = 'host.com'
         config.key      = 'secret'
         config.username = 'username'
-        config.password = 'secret2'
       end
 
       opensrs = MooMoo::BaseCommand.new
@@ -23,7 +22,6 @@ describe MooMoo do
       opensrs.host.should     == 'host.com'
       opensrs.key.should      == 'secret'
       opensrs.username.should == 'username'
-      opensrs.password.should == 'secret2'
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,12 +58,10 @@ RSpec.configure do |c|
         config.host     = ENV['OPENSRS_TEST_URL'] if ENV['OPENSRS_TEST_URL']
         config.key      = ENV['OPENSRS_TEST_KEY']  || raise(ArgumentError, "OPENSRS_TEST_KEY is required")
         config.username = ENV['OPENSRS_TEST_USER'] || raise(ArgumentError, "OPENSRS_TEST_USER is required")
-        config.password = ENV['OPENSRS_TEST_PASS'] || raise(ArgumentError, "OPENSRS_TEST_PASS is required")
       else
         config.host     = "testhost.com"
         config.key      = "testkey"
         config.username = "testuser"
-        config.password = "testpass"
       end
     end
   end


### PR DESCRIPTION
OpenSRS only requires a password with the change password API command. We require one in the configuration and it is never sent upstream. 
