### PR TITLE
Remove vim specific gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
-*.swp
-*.swo
 coverage


### PR DESCRIPTION
These are developer-specific and belong in `~/.gitignore`.
