### PR TITLE
Remove rcov references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .bundle
 Gemfile.lock
 pkg/*
-coverage

--- a/Rakefile
+++ b/Rakefile
@@ -8,15 +8,6 @@ rescue LoadError
 end
 
 begin
-  require 'metric_fu'
-  MetricFu::Configuration.run do |config|
-    config.rcov[:rcov_opts] << "-Ispec"
-  end
-rescue LoadError
-  puts "Can't load metric_fu"
-end
-
-begin
   require 'rdoc/task'
   Rake::RDocTask.new do |rdoc|
     version = MooMoo::VERSION
@@ -61,11 +52,5 @@ end
 
 RSpec::Core::RakeTask.new :spec
 Bundler::GemHelper.install_tasks
-
-desc  "Run all specs with rcov"
-RSpec::Core::RakeTask.new(:rcov) do |t|
-  t.rcov = true
-  t.rcov_opts = %w{--exclude osx\/objc,gems\/,spec\/,features\/ --comments}
-end
 
 task :default => [:spec]


### PR DESCRIPTION
rcov only works with Ruby 1.8 which reached its End Of Life a year ago.
