### PR TITLE
Remove `rake console`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,8 +69,3 @@ RSpec::Core::RakeTask.new(:rcov) do |t|
 end
 
 task :default => [:spec]
-
-desc "Open an irb session preloaded with this library"
-task :console do
-  sh "irb -rubygems -r ./lib/moo_moo.rb"
-end


### PR DESCRIPTION
Bundler has its own command, `bundle console` for this
